### PR TITLE
MINOR: Update table.md refs to state-table.md

### DIFF
--- a/docs/compositional-patterns/command-query-responsibility-segregation.md
+++ b/docs/compositional-patterns/command-query-responsibility-segregation.md
@@ -20,7 +20,7 @@ So for example, the current balance of your account would be the total of all th
 
 ## Implementation
 
-The streaming database [ksqlDB](https://ksqldb.io/) can implement a CQRS using an [Event Stream](../event-stream/event-stream.md) and [Table](../table/table.md).
+The streaming database [ksqlDB](https://ksqldb.io/) can implement a CQRS using an [Event Stream](../event-stream/event-stream.md) and [Table](../table/state-table.md).
 
 [Event Streams](../event-stream/event-stream.md) are built into to the streaming database design. Creating a new stream is straightforward:
 
@@ -38,7 +38,7 @@ INSERT INTO purchases (customer, item, qty) VALUES ('jsmith', 'pants', 1);
 INSERT INTO purchases (customer, item, qty) VALUES ('jsmith', 'pants', -1);
 ```
 
-We can create a [Materialized View](https://docs.ksqldb.io/en/latest/concepts/materialized-views/) of the data as a [Table](../table/table.md):
+We can create a [Materialized View](https://docs.ksqldb.io/en/latest/concepts/materialized-views/) of the data as a [Table](../table/state-table.md):
 ```sql  
 CREATE TABLE customer_purchases WITH (KEY_FORMAT='JSON') AS
   SELECT customer, item, SUM(qty) as total_qty from purchases GROUP BY customer, item emit changes;

--- a/docs/event-processing/event-processing-application.md
+++ b/docs/event-processing/event-processing-application.md
@@ -22,9 +22,9 @@ For example, an application can read a stream of customer payments from an [Even
 Apache Kafka® is the most popular [Event Streaming Platform](../event-stream/event-streaming-platform.md). There are several options for building Event Processing Applications when using Kafka, and we'll show two here.
 
 ### ksqlDB
-[ksqlDB](https://ksqldb.io) is a streaming database with which we can build Event Processing Applications using SQL syntax. It has first-class support for [Streams](../event-stream/event-stream.md) and [Tables](../table/table.md).
+[ksqlDB](https://ksqldb.io) is a streaming database with which we can build Event Processing Applications using SQL syntax. It has first-class support for [Streams](../event-stream/event-stream.md) and [Tables](../table/state-table.md).
 
-When we create [Tables](../table/table.md) and [Streams](../event-stream/event-stream.md) in ksqlDB, then Kafka topics are used as the storage layer behind the scenes. In the example below, the ksqlDB table `movies` is backed by a Kafka topic of the same name.
+When we create [Tables](../table/state-table.md) and [Streams](../event-stream/event-stream.md) in ksqlDB, then Kafka topics are used as the storage layer behind the scenes. In the example below, the ksqlDB table `movies` is backed by a Kafka topic of the same name.
 ```sql
 CREATE TABLE movies (ID INT PRIMARY KEY, title VARCHAR, release_year INT)
     WITH (kafka_topic='movies', partitions=1, value_format='avro');

--- a/docs/event-processing/event-processor.md
+++ b/docs/event-processing/event-processor.md
@@ -44,7 +44,7 @@ With ksqlDB, you can view each section of the command as the construction of a d
 * `EMIT CHANGES` is ksqlDB syntax which defines our query as continuously running, and that incremental changes will be produced as the query runs perpetually.
 
 #### Kafka Streams
-The [Kafka Streams DSL](https://docs.confluent.io/platform/current/streams/developer-guide/dsl-api.html) provides abstractions for [Event Streams](../event-stream/event-stream.md) and [Tables](../table/table.md) as well as stateful and stateless transformation functions (`map`, `filter`, etc...). These functions act as the Event Processor in the larger [Event Processing Application](../event-processing/event-processor.md) you build with the Kafka Streams library.
+The [Kafka Streams DSL](https://docs.confluent.io/platform/current/streams/developer-guide/dsl-api.html) provides abstractions for [Event Streams](../event-stream/event-stream.md) and [Tables](../table/state-table.md) as well as stateful and stateless transformation functions (`map`, `filter`, etc...). These functions act as the Event Processor in the larger [Event Processing Application](../event-processing/event-processor.md) you build with the Kafka Streams library.
 
 ```java
 builder


### PR DESCRIPTION
### Description

Some of the patterns reference `table.md` but should be `state-table.md` instead