### PR TITLE
Adding a script that will check the table of contents for missing TOC entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@
 - [ ] Provide references
 - [ ] Validate hyperlinks
 - [ ] Spell check (e.g. using `aspell`)
+- [ ] Added to table of contents in `docs/meta.yml` (hint: run `./check_toc.sh` to confirm)

--- a/check_toc.sh
+++ b/check_toc.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# You will need to install `yq` locally if you don't already have it. It's a
+# wrapper around `jq` that makes simple YAML-munging easy.
+
 echo "< Markdown exists, no TOC entry"
 echo "> TOC entry, markdown doesn't exist"
 

--- a/check_toc.sh
+++ b/check_toc.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "< Markdown exists, no TOC entry"
+echo "> TOC entry, markdown doesn't exist"
+
+function files {
+    cd docs
+    find . -name '*.md' | sort
+}
+
+function toc {
+    cat docs/meta.yml | yq -r '.toc[].items|.[]' | sed -e 's!.*!./&.md!' | sort
+}
+
+diff <(files) <(toc)


### PR DESCRIPTION
@rspurgeon @ybyzek This should help us check the `docs/meta.yml` file.