### PR TITLE
Use responseEvent to configure response

### DIFF
--- a/docs/event/correlation-identifier.md
+++ b/docs/event/correlation-identifier.md
@@ -26,8 +26,8 @@ requestEvent.send(producerRecord);
 In the responding event processor, we first extract the correlation identifier from the request event (here, the identifier is called `requestID`) and then add that identifier to the response event.
 ```Java
 ProducerRecord<String, String> responseEvent = new ProducerRecord<>("response-event-key", "response-event-value"); 
-requestEvent.headers().add("requestID", requestEvent.headers().lastHeader("requestID").value());
-requestEvent.send(producerRecord);
+responseEvent.headers().add("requestID", requestEvent.headers().lastHeader("requestID").value());
+responseEvent.send(producerRecord);
 ```
 
 ## References


### PR DESCRIPTION
Fixes what likely was a copy-paste error when the pattern description was written.

Original bug report at https://forum.confluent.io/t/how-do-correlation-identifiers-work/2864/2.