### PR TITLE
Command Event: Align more closely with EIP terminology

### DIFF
--- a/docs/event/command.md
+++ b/docs/event/command.md
@@ -1,18 +1,18 @@
 ---
 seo:
-  title: Command Event
-  description: Command Events are a common pattern in evolving event streaming architectures, where events are used as triggers for further processing. They may indicate opportunities for further decoupling and separation of responsibilities.
+  title: Command
+  description: Command Messages are a common pattern in evolving event streaming architectures, where commands are used as triggers for further processing. They may indicate opportunities for further decoupling and separation of responsibilities.
 ---
 
-# Command Event
+# Command
 
-[Events](../event/event.md) often fall into one of two categories: messages and commands.
+Messages often fall into one of two categories: [Events](../event/event.md) and commands.
 
-Message-like events resemble simple facts--a user sends 
+Messages like events resemble simple facts--a user sends 
 their new address, a product leaves the warehouse--and we record
 these facts first, without immediately considering what happens next.
 
-Other events resemble commands to invoke a specific action--a user clicks a `[BUY]` button--and the system takes the action (for example, by triggering order processing).
+Others resemble commands to invoke a specific action--a user clicks a `[BUY]` button--and the system takes the action (for example, by triggering order processing).
 
 ## Problem
 
@@ -21,13 +21,13 @@ How can we use an [Event Streaming Platform](../event-stream/event-streaming-pla
 ## Solution
 ![Command Event](../img/command-event1.svg)
 
-Separate out the function call into a service that writes an event to
+Separate out the function call into a service that writes a command to
 an [Event Stream](../event-stream/event-stream.md), detailing the
 necessary action and its arguments. Then write a separate
-service that watches for that event before invoking the
+service that watches for that command before invoking the
 procedure.
 
-In terms of application logic, a Command Event is typically dispatched in a fire-and-forget manner (events themselves are delivered and stored with strong guarantees, such as exactly-once semantics).  The writer assumes that the event will be handled correctly, and the responsibility for monitoring and error-handling falls elsewhere in the system.  This is very similar to the Actor model: actors have an inbox, and we write messages to that inbox and trust that they will be handled in due course.
+In terms of application logic, a Command is typically dispatched in a fire-and-forget manner (commands themselves are delivered and stored with strong guarantees, such as exactly-once semantics).  The writer assumes that the command will be handled correctly, and the responsibility for monitoring and error-handling falls elsewhere in the system.  This is very similar to the Actor model: actors have an inbox, and we write messages to that inbox and trust that they will be handled in due course.
 
 If a return value is explicitly required, the downstream service can
 write a result event back to a second stream. Correlation of Command
@@ -92,14 +92,14 @@ recipient, we've decoupled the function call _without_ decoupling the
 underlying concepts. When we do that, the architecture responds with
 growing pains<sup>1</sup>.
 
-A better solution is to realize that our "Command Event" is actually two
+A better solution is to realize that our "Command" is actually two
 concepts woven together: "What happened?" and "Who needs to know?" 
 
 By teasing those concepts apart, we can clean up our architecture. We
 allow one process to focus on recording the facts of what happened,
 while other processes decide for themselves if they care about those facts.  
 When the `[BUY]` click happens, we should just write an `Order`
-event. Then warehousing, notifications, and sales can choose to react,
+command. Then warehousing, notifications, and sales can choose to react,
 without any need for coordination.
 
 ![Command Event](../img/command-event2.svg)

--- a/docs/event/event.md
+++ b/docs/event/event.md
@@ -37,7 +37,7 @@ producer.send(producerRecord);
 
 * For cloud-based architectures, evaluate the use of [CloudEvents](https://cloudevents.io/). CloudEvents provide a standardized [Event Envelope](../event/event-envelope.md) that wraps an event, making common event properties such as source, type, time, and ID universally accessible, regardless of how the event itself was serialized.
 
-* In certain scenarios, Events may represent commands (instructions, actions, and so on) that should be carried out by an Event Processor reading the events. See the [Command Event](../event/command-event.md) pattern for details.
+* In certain scenarios, Events may represent commands (instructions, actions, and so on) that should be carried out by an Event Processor reading the events. See the [Command](../event/command.md) pattern for details.
 
 ## References
 * This pattern is derived in part from [Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/Message.html), [Event Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/EventMessage.html), and [Document Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/DocumentMessage.html) in _Enterprise Integration Patterns_, by Gregor Hohpe and Bobby Woolf.

--- a/docs/meta.yml
+++ b/docs/meta.yml
@@ -6,7 +6,7 @@ toc:
   - title: Event
     items:
       - event/event
-      - event/command-event
+      - event/command
       - event/correlation-identifier
       - event/data-contract
       - event/event-deserializer


### PR DESCRIPTION
 Changed the content of the pattern to follow the EIP classification of message types more closely while adhering as much as possible to the style guide (`Prefer the term Event over Message or Record`)

Renamed command-event.md to command.md : following the same naming convention as event.md

### Description

https://github.com/confluentinc/event-streaming-patterns/issues/257

