### PR TITLE
Resolved Command Event to just Command, with minimal changes

### DIFF
--- a/docs/event/command.md
+++ b/docs/event/command.md
@@ -1,25 +1,23 @@
 ---
 seo:
-  title: Command Event
-  description: Command Events are a common pattern in evolving event streaming architectures, where events are used as triggers for further processing. They may indicate opportunities for further decoupling and separation of responsibilities.
+  title: Command
+  description: Commands are a common pattern in evolving event streaming architectures, issued as an instruction to a specific recipient to perform a task. Commands may indicate opportunities for further decoupling and separation of responsibilities.
 ---
 
-# Command Event
+# Command
 
-[Events](../event/event.md) often fall into one of two categories: messages and commands.
-
-Message-like events resemble simple facts--a user sends 
+Events pertain to facts--a user sends 
 their new address, a product leaves the warehouse--and we record
 these facts first, without immediately considering what happens next.
 
-Other events resemble commands to invoke a specific action--a user clicks a `[BUY]` button--and the system takes the action (for example, by triggering order processing).
+In contrast, commands are for invoking a specific action--a user clicks a `[BUY]` button--and the system takes the action (for example, by triggering order processing).
 
 ## Problem
 
 How can we use an [Event Streaming Platform](../event-stream/event-streaming-platform.md) to invoke a procedure in another application?
 
 ## Solution
-![Command Event](../img/command-event1.svg)
+![Command](../img/command-event1.svg)
 
 Separate out the function call into a service that writes an event to
 an [Event Stream](../event-stream/event-stream.md), detailing the
@@ -27,7 +25,7 @@ necessary action and its arguments. Then write a separate
 service that watches for that event before invoking the
 procedure.
 
-In terms of application logic, a Command Event is typically dispatched in a fire-and-forget manner (events themselves are delivered and stored with strong guarantees, such as exactly-once semantics).  The writer assumes that the event will be handled correctly, and the responsibility for monitoring and error-handling falls elsewhere in the system.  This is very similar to the Actor model: actors have an inbox, and we write messages to that inbox and trust that they will be handled in due course.
+In terms of application logic, a Command is typically dispatched in a fire-and-forget manner (the actual record representing the command is delivered and stored with strong guarantees, such as exactly-once semantics).  The writer assumes that the command will be handled correctly, and the responsibility for monitoring and error-handling falls elsewhere in the system.  This is very similar to the Actor model: actors have an inbox, and we write messages to that inbox and trust that they will be handled in due course.
 
 If a return value is explicitly required, the downstream service can
 write a result event back to a second stream. Correlation of Command
@@ -92,7 +90,7 @@ recipient, we've decoupled the function call _without_ decoupling the
 underlying concepts. When we do that, the architecture responds with
 growing pains<sup>1</sup>.
 
-A better solution is to realize that our "Command Event" is actually two
+A better solution is to realize that our "Command" is actually two
 concepts woven together: "What happened?" and "Who needs to know?" 
 
 By teasing those concepts apart, we can clean up our architecture. We
@@ -102,7 +100,7 @@ When the `[BUY]` click happens, we should just write an `Order`
 event. Then warehousing, notifications, and sales can choose to react,
 without any need for coordination.
 
-![Command Event](../img/command-event2.svg)
+![Command](../img/command-event2.svg)
 
 In short, commands are tightly coupled to an audience of one, whereas
 an event should be simply a decoupled fact, available for anyone 

--- a/docs/event/event.md
+++ b/docs/event/event.md
@@ -37,7 +37,7 @@ producer.send(producerRecord);
 
 * For cloud-based architectures, evaluate the use of [CloudEvents](https://cloudevents.io/). CloudEvents provide a standardized [Event Envelope](../event/event-envelope.md) that wraps an event, making common event properties such as source, type, time, and ID universally accessible, regardless of how the event itself was serialized.
 
-* In certain scenarios, Events may represent commands (instructions, actions, and so on) that should be carried out by an Event Processor reading the events. See the [Command Event](../event/command-event.md) pattern for details.
+* In certain scenarios, Events may represent commands (instructions, actions, and so on) that should be carried out by an Event Processor reading the events. See the [Command](../event/command.md) pattern for details.
 
 ## References
 * This pattern is derived in part from [Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/Message.html), [Event Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/EventMessage.html), and [Document Message](https://www.enterpriseintegrationpatterns.com/patterns/messaging/DocumentMessage.html) in _Enterprise Integration Patterns_, by Gregor Hohpe and Bobby Woolf.

--- a/docs/meta.yml
+++ b/docs/meta.yml
@@ -6,7 +6,7 @@ toc:
   - title: Event
     items:
       - event/event
-      - event/command-event
+      - event/command
       - event/correlation-identifier
       - event/data-contract
       - event/event-deserializer


### PR DESCRIPTION
### Description

https://github.com/confluentinc/event-streaming-patterns/issues/261

### New Pattern Checklist
- [YES] Pattern file name should follow `docs/pattern-category/pattern-name.md`
- [N/A ] Create an on-brand diagram (https://docs.google.com/presentation/d/1Zf256Z6fBvre3uclIbmxXsDpnTIxiBX66b13pHbGIYc/edit?usp=sharing)
- [N/A] Implement ksqlDB or code example (not all patterns will have code, but highly desired)
- [N/A] Provide references
- [YES] Validate hyperlinks
- [YES] Spell check (e.g. using `aspell`)
- [YES] Added to table of contents in `docs/meta.yml` (hint: run `./check_toc.sh` to confirm)
